### PR TITLE
Fixed djangosaml2 version requirement

### DIFF
--- a/taiga-contrib-inps/back/setup.py
+++ b/taiga-contrib-inps/back/setup.py
@@ -21,6 +21,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "djangosaml2-spid @ git+https://git@github.com/italia/spid-django.git@main#egg=djangosaml2-spid",
+        "djangosaml2 < 1.5.0",
         "spid_compliant_certificates @ git+https://git@github.com/italia/spid-compliant-certificates-python.git@main#egg=spid_compliant_certificates",
     ],
     setup_requires=[

--- a/taiga-contrib-inps/spid_inps/setup.py
+++ b/taiga-contrib-inps/spid_inps/setup.py
@@ -21,6 +21,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "djangosaml2-spid @ git+https://git@github.com/italia/spid-django.git@main#egg=djangosaml2-spid",
+        "djangosaml2 < 1.5.0",
         "spid_compliant_certificates @ git+https://git@github.com/italia/spid-compliant-certificates-python.git@main#egg=spid_compliant_certificates"
     ],
     setup_requires=[


### PR DESCRIPTION
## Description

Added "djangosaml2 < 1.5.0" to 'install_requires' list of setup.py module of both 'back' and 'spid-inps' directories, to override the version specified in https://github.com/italia/spid-django 's requirements.txt, which is not compatible with deprecated version of Django used by Taiga.

## Checklist

- [ ] I have followed the indications in the [CONTRIBUTING](https://github.com/INPS-it/taiga-inps-bug-tracking/blob/main/CONTRIBUTING.md).
- [ ] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [ ] I have successfully run tests with my changes locally.
- [ ] It is ready for review! :rocket:

## Fixes


- Fixes #28 
