### PR TITLE
Fixes scrollbars appearing when not needed

### DIFF
--- a/taiga-inps-theme/custom.scss
+++ b/taiga-inps-theme/custom.scss
@@ -465,7 +465,7 @@ a.secondary:hover {
 
 .main {
     @media (max-width: $xl) {
-        overflow-y: scroll;
+        overflow-y: auto;
     }
 }
 


### PR DESCRIPTION
Some UI elements had scrollbars even when their content did not overflow their height. Example:

<img width="880" alt="Immagine 2022-07-24 142319" src="https://user-images.githubusercontent.com/84072632/180647911-c8835a64-9850-42a1-8571-dd037da817cc.png">
